### PR TITLE
[TF2] Decouple TF_COND_HALLOWEEN_THRILLER from blocked input, instead…

### DIFF
--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -6496,11 +6496,16 @@ bool C_TFPlayer::CreateMove( float flInputSampleTime, CUserCmd *pCmd )
 	static float flTauntTurnSpeed = 0.f;
 	
 	bool bNoTaunt = true;
-	bool bInTaunt = m_Shared.InCond( TF_COND_TAUNTING ) || m_Shared.InCond( TF_COND_HALLOWEEN_THRILLER );
+	bool bInTaunt = m_Shared.InCond( TF_COND_TAUNTING );
 
 	if ( m_Shared.InCond( TF_COND_FREEZE_INPUT ) )
 	{
-		pCmd->viewangles = angMoveAngle; // use the last save angles
+		if ( !m_Shared.InCond( TF_COND_HALLOWEEN_THRILLER ) )
+		{
+			// if NOT halloween taunt, force their last-saved view angles
+			// (thriller allows it so teleports can set the correct view angles)
+			pCmd->viewangles = angMoveAngle;
+		}
 		pCmd->forwardmove = 0.0f;
 		pCmd->sidemove = 0.0f;
 		pCmd->upmove = 0.0f;

--- a/src/game/client/tf/clientmode_tf.cpp
+++ b/src/game/client/tf/clientmode_tf.cpp
@@ -156,12 +156,6 @@ static bool HalloweenHandlesKeyInput( int down, ButtonCode_t keynum, const char 
 	C_TFPlayer *pPlayer = ToTFPlayer( C_BasePlayer::GetLocalPlayer() );
 	if ( pPlayer )
 	{
-		// don't do anything while dancing
-		if ( pPlayer->m_Shared.InCond( TF_COND_HALLOWEEN_THRILLER ) )
-		{
-			return true;
-		}
-
 		// only allow +attack
 		if ( pPlayer->m_Shared.InCond( TF_COND_HALLOWEEN_GHOST_MODE ) )
 		{

--- a/src/game/server/tf/bot/behavior/tf_bot_behavior.cpp
+++ b/src/game/server/tf/bot/behavior/tf_bot_behavior.cpp
@@ -107,7 +107,7 @@ ActionResult< CTFBot >	CTFBotMainAction::Update( CTFBot *me, float interval )
 		return Done( "Not on a playing team" );
 	}
 
-	if ( me->m_Shared.InCond( TF_COND_FREEZE_INPUT ) || me->m_Shared.InCond( TF_COND_HALLOWEEN_THRILLER ) )
+	if ( me->m_Shared.InCond( TF_COND_FREEZE_INPUT ) )
 	{
 		// frozen - do nothing
 		return SuspendFor( new CTFBotFreezeInput, "Frozen by TF_COND" );

--- a/src/game/server/tf/bot/behavior/tf_bot_freeze_input.cpp
+++ b/src/game/server/tf/bot/behavior/tf_bot_freeze_input.cpp
@@ -11,7 +11,7 @@
 //---------------------------------------------------------------------------------------------
 ActionResult< CTFBot > CTFBotFreezeInput::Update( CTFBot *me, float interval )
 {
-	if ( !me->m_Shared.InCond( TF_COND_FREEZE_INPUT ) && !me->m_Shared.InCond( TF_COND_HALLOWEEN_THRILLER ) )
+	if ( !me->m_Shared.InCond( TF_COND_FREEZE_INPUT ) )
 	{
 		return Done( "No longer frozen by TF_COND" );
 	}

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -3160,7 +3160,7 @@ void CTFPlayer::PlayerRunCommand( CUserCmd *ucmd, IMoveHelper *moveHelper )
 	{
 		m_Shared.CreateVehicleMove( gpGlobals->frametime, ucmd );
 	}
-	else if ( IsTaunting() || m_Shared.InCond( TF_COND_HALLOWEEN_THRILLER ) )
+	else if ( IsTaunting() )
 	{
 		// For some taunts, it is critical that the player not move once they start
 		if ( !CanMoveDuringTaunt() )
@@ -4931,6 +4931,9 @@ void CTFPlayer::UseActionSlotItemPressed( void )
 		DoNoiseMaker();
 		return;
 	}
+
+	if ( m_Shared.InCond( TF_COND_FREEZE_INPUT ) )
+		return;
 
 	CBaseEntity *pActionSlotEntity = GetEntityForLoadoutSlot( LOADOUT_POSITION_ACTION );
 	if ( !pActionSlotEntity )
@@ -18256,6 +18259,12 @@ void CTFPlayer::HandleTauntCommand( int iTauntSlot )
 	if ( !IsAllowedToTaunt() )
 		return;
 
+	if ( m_Shared.InCond( TF_COND_HALLOWEEN_THRILLER ) )
+	{
+		// Don't allow econ taunts during thriller cond
+		Taunt();
+		return;
+	}
 	m_nActiveTauntSlot = LOADOUT_POSITION_INVALID;
 	if ( iTauntSlot > 0 && iTauntSlot <= 8 )
 	{
@@ -19504,7 +19513,7 @@ void CTFPlayer::ModifyOrAppendCriteria( AI_CriteriaSet& criteriaSet )
 	}
 
 	// Force the thriller taunt if we have the thriller condition
-	if( m_Shared.InCond( TF_COND_HALLOWEEN_THRILLER ) )
+	if ( m_Shared.InCond( TF_COND_HALLOWEEN_THRILLER ) )
 	{
 		criteriaSet.AppendCriteria( "IsHalloweenTaunt", "1" );
 	}

--- a/src/game/shared/tf/halloween/tf_weapon_spellbook.cpp
+++ b/src/game/shared/tf/halloween/tf_weapon_spellbook.cpp
@@ -866,10 +866,10 @@ bool CTFSpellBook::HasASpellWithCharges()
 //-----------------------------------------------------------------------------
 bool CTFSpellBook::CanCastSpell( CTFPlayer *pPlayer )
 {
-	if ( !pPlayer->m_Shared.InCond( TF_COND_HALLOWEEN_KART) && !pPlayer->CanAttack() )
+	if ( !pPlayer->m_Shared.InCond( TF_COND_HALLOWEEN_KART ) && !pPlayer->CanAttack() )
 		return false;
 
-	if ( pPlayer->m_Shared.InCond( TF_COND_HALLOWEEN_THRILLER ) )
+	if ( pPlayer->m_Shared.InCond( TF_COND_FREEZE_INPUT ) )
 		return false;
 
 	if ( tf_test_spellindex.GetInt() > -1 && tf_test_spellindex.GetInt() < GetTotalSpellCount( pPlayer ) )

--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -4489,7 +4489,9 @@ void CTFPlayerShared::OnAddHalloweenThriller( void )
 			m_pOuter->EmitSound( "Halloween.dance_loop" );	
 		}
 	}
-#endif
+#else
+	AddCond( TF_COND_FREEZE_INPUT );
+#endif // CLIENT_DLL
 }
 
 void CTFPlayerShared::OnRemoveHalloweenThriller( void )
@@ -4505,6 +4507,7 @@ void CTFPlayerShared::OnRemoveHalloweenThriller( void )
 		}
 	}
 #else
+	RemoveCond( TF_COND_FREEZE_INPUT );
 	// If this is hightower, players will be healing themselves while dancing
 	StopHealing( m_pOuter );
 #endif
@@ -12996,7 +12999,7 @@ bool CTFPlayer::CanMoveDuringTaunt()
 	if ( m_Shared.InCond( TF_COND_HALLOWEEN_KART ) )
 		return true;
 
-	if ( m_Shared.InCond( TF_COND_TAUNTING ) || m_Shared.InCond( TF_COND_HALLOWEEN_THRILLER ) )
+	if ( m_Shared.InCond( TF_COND_TAUNTING ) )
 	{
 #ifdef GAME_DLL
 		if ( tf_allow_sliding_taunt.GetBool() )


### PR DESCRIPTION
… adding FREEZE_INPUT when it is added to provide the same effects

HALLOWEEN_THRILLER now only plays the music and forces the Halloween taunt when attempting to taunt. To maintain backwards compatibility with custom maps that may use it, it also adds FREEZE_INPUT when added. This results in the same behavior as stock for all maps. This now allows HALLOWEEN_THRILLER to open console, which helps avoid a softlock when using `addcond 54` and offers greater flexibility for using the Thriller condition (maps may add it then remove FREEZE_INPUT immediately to use it by itself). This prevents using action slot during FREEZE_INPUT. This also prevents using econ taunts while in HALLOWEEN_THRILLER, forcing the Thriller taunt instead. In order for the functionality of the Dance events in various maps to remain consistent, players are allowed to look around during FREEZE_INPUT if they also have HALLOWEEN_THRILLER.

<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
